### PR TITLE
 chore(eslint): re-enable strict typescript linting rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,13 +61,6 @@ export default tseslint.config(
           format: ["PascalCase"],
         },
       ],
-      // This rule is usually too strict for mixed JS/TS projects or those with complex data flows
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-call": "off",
-      "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/no-unsafe-argument": "off",
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "@typescript-eslint/no-redundant-type-constituents": "off", // Temporarily disable to reduce noise
     },
   },
 


### PR DESCRIPTION
## 🛡️ Enhancing Type Safety Configuration

### 📝 Summary
This PR updates our `eslint.config.mjs` to re-enable several strict TypeScript rules that were previously muted. Since our codebase is already clean and compliant, this is purely a configuration change to prevent future regressions.

### 🛠️ What Changed
We removed the overrides that disabled the following `@typescript-eslint` rules:

*   `no-unsafe-assignment`
*   `no-unsafe-call`
*   `no-unsafe-member-access`
*   `no-unsafe-argument`
*   `restrict-template-expressions`
*   `no-redundant-type-constituents`

### ✅ Benefits
*   **Stricter Type Checking:** Prevents `any` types from silently bypassing our type system.
*   **Cleaner Code:** Ensures string interpolation is used correctly and type definitions remain logical.
*   **Reliability:** Catches potential runtime errors during development.

### 🧪 Verification
*   Ran `npm run lint` successfully (0 errors found).
*   Manually tested each rule by introducing temporary violations to ensure the linter correctly flags them.