### PR TITLE
chore: update copyright year in electron-builder config

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.app.dartsmate
 productName: DartsMate
-copyright: Copyright © 2022-2025 DartsMate Contributors
+copyright: Copyright © 2022-2026 DartsMate Contributors
 directories:
   output: dist
   buildResources: resources


### PR DESCRIPTION
Changed the copyright year range in electron-builder.yml to reflect the current year.