### PR TITLE
Update 0.6.1

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -38,18 +38,14 @@ void (async () => {
   const defaultProfile = appSettingsStore.get("defaultProfileUUID");
 
   const updaterWindow = createWindow("updater", {
-    // alwaysOnTop: true,
-    resizable: !IS_APP_RUNNING_IN_PRODUCTION_MODE ? false : true,
     center: true,
-    closable: !IS_APP_RUNNING_IN_PRODUCTION_MODE ? false : true,
-    minimizable: !IS_APP_RUNNING_IN_PRODUCTION_MODE ? false : true,
     height: 500,
     minHeight: 500,
     minWidth: 500,
     width: 500,
     maxHeight: 500,
     maxWidth: 500,
-    frame: !IS_APP_RUNNING_IN_PRODUCTION_MODE ? false : true,
+    frame: !IS_APP_RUNNING_IN_PRODUCTION_MODE,
     webPreferences: {
       contextIsolation: true,
       preload: path.join(__dirname, "preload.js"),

--- a/main/helpers/updater.ts
+++ b/main/helpers/updater.ts
@@ -3,9 +3,10 @@ import {
   type ProgressInfo,
   type UpdateInfo,
 } from "electron-updater";
-import { ipcMain, app, BrowserWindow } from "electron";
+import { ipcMain, BrowserWindow } from "electron";
 import log from "electron-log";
 import { getWindow } from "./window-registry";
+import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
 
 /**
  * Registers the application updater and sets up IPC handlers for update events.
@@ -15,25 +16,6 @@ import { getWindow } from "./window-registry";
 let isUpdateInstalling = false;
 
 const registerUpdater = () => {
-  // Skipping auto-updater in development mode
-  if (!app.isPackaged) {
-    return;
-
-    // Use this to simulate an update event to test the bridge
-    /*
-    setTimeout(() => {
-      BrowserWindow.getAllWindows().forEach((window) => {
-        log.info("[Updater] Sending fake update-message");
-        window.webContents.send("update-message", {
-          event: "available",
-          data: { version: "9.9.9" },
-        });
-      });
-    }, 2000);
-    return;
-    */
-  }
-
   autoUpdater.autoDownload = false;
   autoUpdater.logger = log;
 
@@ -58,6 +40,15 @@ const registerUpdater = () => {
   autoUpdater.on("error", (err) => broadcast("error", err));
 
   ipcMain.handle("check-for-app-update", async () => {
+    if (!IS_APP_RUNNING_IN_PRODUCTION_MODE) {
+      broadcast(
+        "not-available",
+        // Not really an error since this the expected behavior in development mode
+        // But this way we can see in the electron log that update checks were attempted
+        new Error("Updates are disabled in development mode!"),
+      );
+      return;
+    }
     return await autoUpdater.checkForUpdates();
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dartsmate",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dartsmate",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "dependencies": {
         "@mantine/charts": "^8.3.13",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "dartsmate",
   "productName": "DartsMate",
   "description": "Analyze, track and compare your dart games.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "DartsMate Contributors",
   "main": "app/background.js",
   "repository": "https://github.com/timderes/dartsmate",


### PR DESCRIPTION
TLDR; Hot fix for the updater window

This pull request primarily improves how the app handles update functionality between development and production modes, ensuring that update checks and updater windows behave correctly in each environment. It also bumps the app version to `0.6.1`.

**Updater logic and environment handling:**

* The updater registration logic in `main/helpers/updater.ts` was refactored to use the `IS_APP_RUNNING_IN_PRODUCTION_MODE` constant instead of relying on `app.isPackaged`, improving clarity and consistency across the codebase.
* Update checks are now explicitly disabled in development mode. When a check is attempted in development, a "not-available" event is broadcast with an informative error message, making it clear in logs and UI that updates are not available in development.
* The import of the `app` module from Electron was removed where it was no longer needed, and the new constant was imported for environment checks.

**Window configuration changes:**

* The updater window in `main/background.ts` now uses the `frame` property based on the production mode constant, and other window properties were simplified for better maintainability and clarity.

**Version bump:**

* The app version was updated from `0.6.0` to `0.6.1` in `package.json`.