### PR TITLE
fix: make checkout options translatable

### DIFF
--- a/renderer/pages/[locale]/lobby/index.tsx
+++ b/renderer/pages/[locale]/lobby/index.tsx
@@ -302,7 +302,24 @@ const NewGamePage = () => {
               label={t("lobby:checkout")}
               {...matchSettings.getInputProps("matchCheckout")}
               defaultValue={matchSettings.values.matchCheckout}
-              data={["Any", "Single", "Double", "Triple"]}
+              data={[
+                {
+                  label: t("checkouts.any"),
+                  value: "Any",
+                },
+                {
+                  label: t("checkouts.single"),
+                  value: "Single",
+                },
+                {
+                  label: t("checkouts.double"),
+                  value: "Double",
+                },
+                {
+                  label: t("checkouts.triple"),
+                  value: "Triple",
+                },
+              ]}
             />
             <Divider />
             <Button

--- a/renderer/public/locales/de/common.json
+++ b/renderer/public/locales/de/common.json
@@ -48,6 +48,12 @@
     "missed": "Nicht getroffen",
     "rounds": "Runden"
   },
+  "checkouts": {
+    "any": "Beliebig",
+    "single": "Single-Out",
+    "double": "Double-Out",
+    "triple": "Master-Out"
+  },
   "color": {
     "blue": "Blau",
     "cyan": "Türkis",

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -48,6 +48,12 @@
     "missed": "Missed",
     "rounds": "Rounds"
   },
+  "checkouts": {
+    "any": "Any",
+    "single": "Single-Out",
+    "double": "Double-Out",
+    "triple": "Master-Out"
+  },
   "color": {
     "blue": "Blue",
     "cyan": "Cyan",


### PR DESCRIPTION
- Replace static checkout option strings with objects containing translated labels and stable values in renderer/pages/[locale]/lobby/index.tsx, using t("checkouts.*") for i18n. 

- Add corresponding "checkouts" entries to English and German common.json so the select shows localized labels while preserving option values (Any, Single, Double, Triple).

- Fixed the wrong label text for the triple out setting