### PR TITLE
fix(ci): restrict workflow permissions to read-only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint and format code
 
+# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint and format code
 
 # Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
 permissions:
+  actions: write # Needed for caching npm dependencies
   contents: read
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Run all Tests
 
 # Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
 permissions:
+  actions: write # Needed for caching npm dependencies
   contents: read
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Run all Tests
 
+# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Add a permissions block to CI workflows to remove write access. Both .github/workflows/lint.yml and .github/workflows/test.yml now set `permissions: contents: read`