### PR TITLE
feat(updater): display changelog after updating the app

### DIFF
--- a/main/helpers/ipc.ts
+++ b/main/helpers/ipc.ts
@@ -24,6 +24,16 @@ ipcMain.handle("removeDefaultProfileUUID", () => {
   appSettingsStore.delete("defaultProfileUUID");
 });
 
+ipcMain.handle("getLatestSeenChangelogVersion", (): string | undefined => {
+  const version = appSettingsStore.get("latestSeenChangelogVersion");
+  return version;
+});
+
+ipcMain.handle("setLatestSeenChangelogVersion", (_, version: string) => {
+  appSettingsStore.set("latestSeenChangelogVersion", version);
+  log.info(`Set latest seen changelog version to ${version}`);
+});
+
 ipcMain.on("minimize-app-window", () => {
   const focusedWindow = BrowserWindow.getFocusedWindow();
 

--- a/main/helpers/ipc.ts
+++ b/main/helpers/ipc.ts
@@ -20,6 +20,11 @@ ipcMain.handle("getDefaultProfileUUID", (): string | undefined => {
   return uuid;
 });
 
+ipcMain.handle("getUpdateInfo", () => {
+  const updateInfo = appSettingsStore.get("updateInfo");
+  return updateInfo;
+});
+
 ipcMain.handle("removeDefaultProfileUUID", () => {
   appSettingsStore.delete("defaultProfileUUID");
 });

--- a/main/helpers/ipc.ts
+++ b/main/helpers/ipc.ts
@@ -20,11 +20,6 @@ ipcMain.handle("getDefaultProfileUUID", (): string | undefined => {
   return uuid;
 });
 
-ipcMain.handle("getUpdateInfo", () => {
-  const updateInfo = appSettingsStore.get("updateInfo");
-  return updateInfo;
-});
-
 ipcMain.handle("removeDefaultProfileUUID", () => {
   appSettingsStore.delete("defaultProfileUUID");
 });

--- a/main/helpers/stores.ts
+++ b/main/helpers/stores.ts
@@ -1,13 +1,11 @@
 import Store from "electron-store";
 import pkg from "../../package.json";
 import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
-import type { UpdateInfo } from "electron-updater";
 
 type AppSettingsStoreType = {
   defaultProfileUUID?: string;
   locale?: string;
   latestSeenChangelogVersion?: string;
-  updateInfo: UpdateInfo | null;
 };
 
 const lowerCasedProductName = pkg.productName.toLowerCase();

--- a/main/helpers/stores.ts
+++ b/main/helpers/stores.ts
@@ -1,11 +1,13 @@
 import Store from "electron-store";
 import pkg from "../../package.json";
 import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
+import type { UpdateInfo } from "electron-updater";
 
 type AppSettingsStoreType = {
   defaultProfileUUID?: string;
   locale?: string;
   latestSeenChangelogVersion?: string;
+  updateInfo: UpdateInfo | null;
 };
 
 const lowerCasedProductName = pkg.productName.toLowerCase();

--- a/main/helpers/stores.ts
+++ b/main/helpers/stores.ts
@@ -5,6 +5,7 @@ import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
 type AppSettingsStoreType = {
   defaultProfileUUID?: string;
   locale?: string;
+  latestSeenChangelogVersion?: string;
 };
 
 const lowerCasedProductName = pkg.productName.toLowerCase();

--- a/main/helpers/updater.ts
+++ b/main/helpers/updater.ts
@@ -7,6 +7,7 @@ import { ipcMain, BrowserWindow } from "electron";
 import log from "electron-log";
 import { getWindow } from "./window-registry";
 import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
+import { appSettingsStore } from "./stores";
 
 /**
  * Registers the application updater and sets up IPC handlers for update events.
@@ -18,6 +19,7 @@ let isUpdateInstalling = false;
 const registerUpdater = () => {
   autoUpdater.autoDownload = false;
   autoUpdater.logger = log;
+  autoUpdater.fullChangelog = true;
 
   // Send update status to all available app windows
   const broadcast = (
@@ -31,7 +33,11 @@ const registerUpdater = () => {
 
   // Handle all events and broadcast them to renderer process
   autoUpdater.on("checking-for-update", () => broadcast("checking"));
-  autoUpdater.on("update-available", (info) => broadcast("available", info));
+  autoUpdater.on("update-available", (info) => {
+    // Set update info to the electron store, so the changelog can be shown
+    appSettingsStore.set("updateInfo", info ?? null);
+    broadcast("available", info);
+  });
   autoUpdater.on("update-not-available", () => broadcast("not-available"));
   autoUpdater.on("download-progress", (progress) =>
     broadcast("progress", progress),

--- a/main/helpers/updater.ts
+++ b/main/helpers/updater.ts
@@ -7,7 +7,6 @@ import { ipcMain, BrowserWindow } from "electron";
 import log from "electron-log";
 import { getWindow } from "./window-registry";
 import { IS_APP_RUNNING_IN_PRODUCTION_MODE } from "../constants/application";
-import { appSettingsStore } from "./stores";
 
 /**
  * Registers the application updater and sets up IPC handlers for update events.
@@ -19,7 +18,6 @@ let isUpdateInstalling = false;
 const registerUpdater = () => {
   autoUpdater.autoDownload = false;
   autoUpdater.logger = log;
-  autoUpdater.fullChangelog = true;
 
   // Send update status to all available app windows
   const broadcast = (
@@ -34,8 +32,6 @@ const registerUpdater = () => {
   // Handle all events and broadcast them to renderer process
   autoUpdater.on("checking-for-update", () => broadcast("checking"));
   autoUpdater.on("update-available", (info) => {
-    // Set update info to the electron store, so the changelog can be shown
-    appSettingsStore.set("updateInfo", info ?? null);
     broadcast("available", info);
   });
   autoUpdater.on("update-not-available", () => broadcast("not-available"));

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -31,6 +31,9 @@ const handler = {
   setDefaultProfileUUID(uuid: string) {
     void ipcRenderer.invoke("setDefaultProfileUUID", uuid);
   },
+  getUpdateInfo() {
+    return ipcRenderer.invoke("getUpdateInfo");
+  },
   getDefaultProfileUUID() {
     return ipcRenderer.invoke("getDefaultProfileUUID");
   },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -31,9 +31,6 @@ const handler = {
   setDefaultProfileUUID(uuid: string) {
     void ipcRenderer.invoke("setDefaultProfileUUID", uuid);
   },
-  getUpdateInfo() {
-    return ipcRenderer.invoke("getUpdateInfo");
-  },
   getDefaultProfileUUID() {
     return ipcRenderer.invoke("getDefaultProfileUUID");
   },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -22,6 +22,12 @@ const handler = {
   setLocale(locale: string) {
     void ipcRenderer.invoke("setLocale", locale);
   },
+  getLatestSeenChangelogVersion() {
+    return ipcRenderer.invoke("getLatestSeenChangelogVersion");
+  },
+  setLatestSeenChangeLogVersion(version: string) {
+    void ipcRenderer.invoke("setLatestSeenChangelogVersion", version);
+  },
   setDefaultProfileUUID(uuid: string) {
     void ipcRenderer.invoke("setDefaultProfileUUID", uuid);
   },

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -25,7 +25,7 @@ const handler = {
   getLatestSeenChangelogVersion() {
     return ipcRenderer.invoke("getLatestSeenChangelogVersion");
   },
-  setLatestSeenChangeLogVersion(version: string) {
+  setLatestSeenChangelogVersion(version: string) {
     void ipcRenderer.invoke("setLatestSeenChangelogVersion", version);
   },
   setDefaultProfileUUID(uuid: string) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "dartsmate",
   "productName": "DartsMate",
   "description": "Analyze, track and compare your dart games.",
-  "version": "0.6.2",
+  "version": "0.6.0",
   "author": "DartsMate Contributors",
   "main": "app/background.js",
   "repository": "https://github.com/timderes/dartsmate",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "dartsmate",
   "productName": "DartsMate",
   "description": "Analyze, track and compare your dart games.",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "author": "DartsMate Contributors",
   "main": "app/background.js",
   "repository": "https://github.com/timderes/dartsmate",

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -53,6 +53,7 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
       modalId: "changelog-modal",
       fullScreen: true,
       withCloseButton: false,
+      closeOnEscape: false,
       title: t("changelogTitle", { VERSION: APP_VERSION }),
       children: <ChangelogModal />,
       onClose: () => {

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -18,6 +18,7 @@ import { APP_VERSION } from "@utils/constants";
 
 import navbarRoutes from "@utils/content/navbarRoutes";
 import formatLocalizedRoute from "@utils/navigation/formatLocalizedRoute";
+import sharedChangelogModalProps from "@/utils/modals/sharedChangelogModalProps";
 
 /**
  * The navigation sidebar displaying the app routes.
@@ -50,15 +51,12 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
 
   const openChangelogModal = () => {
     modals.open({
-      modalId: "changelog-modal",
-      fullScreen: true,
-      withCloseButton: false,
-      closeOnEscape: false,
       title: t("changelogTitle", { VERSION: APP_VERSION }),
       children: <ChangelogModal />,
       onClose: () => {
         window.ipc.setLatestSeenChangelogVersion(APP_VERSION);
       },
+      ...sharedChangelogModalProps,
     });
   };
 

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "next-i18next";
 import {
   AppShell,
   type AppShellNavbarProps,
+  Button,
   Divider,
   NavLink,
   ScrollAreaAutosize,
@@ -94,15 +95,9 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
             {networkStatus.online ? t("online") : t("offline")}
           </Text>
           {isIndexRoute && (
-            <Text
-              component="span"
-              fz="xs"
-              mt="xs"
-              style={{ cursor: "pointer" }}
-              onClick={openChangelogModal}
-            >
+            <Button fz="xs" variant="transparent" onClick={openChangelogModal}>
               {t("openChangelog")}
-            </Text>
+            </Button>
           )}
         </Stack>
       </AppShell.Section>

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -55,7 +55,7 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
       title: t("changelogTitle", { VERSION: APP_VERSION }),
       children: <ChangelogModal />,
       onClose: () => {
-        window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+        window.ipc.setLatestSeenChangelogVersion(APP_VERSION);
       },
     });
   };

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -2,11 +2,9 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 
 import {
-  ActionIcon,
   AppShell,
   type AppShellNavbarProps,
   Divider,
-  Flex,
   NavLink,
   ScrollAreaAutosize,
   Stack,
@@ -15,9 +13,8 @@ import {
 } from "@mantine/core";
 import { upperFirst, useNetwork, useOs } from "@mantine/hooks";
 import { modals } from "@mantine/modals";
-import { IconStar } from "@tabler/icons-react";
 import ChangelogModal from "@/components/updater/ChangelogModal";
-import { APP_SHELL, APP_VERSION } from "@utils/constants";
+import { APP_VERSION } from "@utils/constants";
 
 import navbarRoutes from "@utils/content/navbarRoutes";
 import formatLocalizedRoute from "@utils/navigation/formatLocalizedRoute";
@@ -87,20 +84,6 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
       </AppShell.Section>
       <Divider />
       <AppShell.Section p="lg">
-        {isIndexRoute && (
-          <Flex justify="center" mb="xs">
-            <Tooltip label={t("openChangelog")} withArrow>
-              <ActionIcon
-                color="gray"
-                size={APP_SHELL.ICON_SIZE}
-                onClick={openChangelogModal}
-                variant="transparent"
-              >
-                <IconStar />
-              </ActionIcon>
-            </Tooltip>
-          </Flex>
-        )}
         <Stack c="dimmed" gap={0} ta="center">
           <Text component="span" fz="xs">
             {APP_VERSION}
@@ -111,6 +94,19 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
           <Text component="span" fz="xs">
             {networkStatus.online ? t("online") : t("offline")}
           </Text>
+          {isIndexRoute && (
+            <Tooltip label={t("openChangelog")} withArrow>
+              <Text
+                component="span"
+                fz="xs"
+                mt="xs"
+                style={{ cursor: "pointer" }}
+                onClick={openChangelogModal}
+              >
+                {t("openChangelog")}
+              </Text>
+            </Tooltip>
+          )}
         </Stack>
       </AppShell.Section>
     </AppShell.Navbar>

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -9,7 +9,6 @@ import {
   ScrollAreaAutosize,
   Stack,
   Text,
-  Tooltip,
 } from "@mantine/core";
 import { upperFirst, useNetwork, useOs } from "@mantine/hooks";
 import { modals } from "@mantine/modals";
@@ -95,17 +94,15 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
             {networkStatus.online ? t("online") : t("offline")}
           </Text>
           {isIndexRoute && (
-            <Tooltip label={t("openChangelog")} withArrow>
-              <Text
-                component="span"
-                fz="xs"
-                mt="xs"
-                style={{ cursor: "pointer" }}
-                onClick={openChangelogModal}
-              >
-                {t("openChangelog")}
-              </Text>
-            </Tooltip>
+            <Text
+              component="span"
+              fz="xs"
+              mt="xs"
+              style={{ cursor: "pointer" }}
+              onClick={openChangelogModal}
+            >
+              {t("openChangelog")}
+            </Text>
           )}
         </Stack>
       </AppShell.Section>

--- a/renderer/components/layouts/shared/AppNavbar.tsx
+++ b/renderer/components/layouts/shared/AppNavbar.tsx
@@ -2,19 +2,25 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 
 import {
+  ActionIcon,
   AppShell,
   type AppShellNavbarProps,
   Divider,
+  Flex,
   NavLink,
   ScrollAreaAutosize,
   Stack,
   Text,
+  Tooltip,
 } from "@mantine/core";
 import { upperFirst, useNetwork, useOs } from "@mantine/hooks";
+import { modals } from "@mantine/modals";
+import { IconStar } from "@tabler/icons-react";
+import ChangelogModal from "@/components/updater/ChangelogModal";
+import { APP_SHELL, APP_VERSION } from "@utils/constants";
 
 import navbarRoutes from "@utils/content/navbarRoutes";
 import formatLocalizedRoute from "@utils/navigation/formatLocalizedRoute";
-import { APP_VERSION } from "@utils/constants";
 
 /**
  * The navigation sidebar displaying the app routes.
@@ -43,6 +49,21 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
     );
   };
 
+  const isIndexRoute = isActiveRoute("/");
+
+  const openChangelogModal = () => {
+    modals.open({
+      modalId: "changelog-modal",
+      fullScreen: true,
+      withCloseButton: false,
+      title: t("changelogTitle", { VERSION: APP_VERSION }),
+      children: <ChangelogModal />,
+      onClose: () => {
+        window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+      },
+    });
+  };
+
   return (
     <AppShell.Navbar {...props}>
       <AppShell.Section component={ScrollAreaAutosize} grow>
@@ -66,6 +87,20 @@ const AppNavbar = ({ ...props }: AppShellNavbarProps) => {
       </AppShell.Section>
       <Divider />
       <AppShell.Section p="lg">
+        {isIndexRoute && (
+          <Flex justify="center" mb="xs">
+            <Tooltip label={t("openChangelog")} withArrow>
+              <ActionIcon
+                color="gray"
+                size={APP_SHELL.ICON_SIZE}
+                onClick={openChangelogModal}
+                variant="transparent"
+              >
+                <IconStar />
+              </ActionIcon>
+            </Tooltip>
+          </Flex>
+        )}
         <Stack c="dimmed" gap={0} ta="center">
           <Text component="span" fz="xs">
             {APP_VERSION}

--- a/renderer/components/updater/ChangelogModal.tsx
+++ b/renderer/components/updater/ChangelogModal.tsx
@@ -25,8 +25,8 @@ const ChangelogModal = () => {
                 {t("features")}
               </Title>
               <List>
-                {(features as string[]).map((feature) => (
-                  <List.Item key={feature}>{feature}</List.Item>
+                {(features as string[]).map((feature, index) => (
+                  <List.Item key={index}>{feature}</List.Item>
                 ))}
               </List>
             </div>
@@ -37,8 +37,8 @@ const ChangelogModal = () => {
                 {t("fixes")}
               </Title>
               <List>
-                {(fixes as string[]).map((fix) => (
-                  <List.Item key={fix}>{fix}</List.Item>
+                {(fixes as string[]).map((fix, index) => (
+                  <List.Item key={index}>{fix}</List.Item>
                 ))}
               </List>
             </div>

--- a/renderer/components/updater/ChangelogModal.tsx
+++ b/renderer/components/updater/ChangelogModal.tsx
@@ -47,7 +47,7 @@ const ChangelogModal = () => {
       ) : (
         <Text fs="italic">{t("noChangelog")}</Text>
       )}
-      <Button onClick={() => modals.close("changelog-modal")}>
+      <Button w="fit-content" onClick={() => modals.close("changelog-modal")}>
         {t("common:next")}
       </Button>
     </Stack>

--- a/renderer/components/updater/ChangelogModal.tsx
+++ b/renderer/components/updater/ChangelogModal.tsx
@@ -1,0 +1,57 @@
+import { Button, List, Stack, Text, Title } from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { useTranslation } from "next-i18next";
+import { APP_VERSION } from "@/utils/constants";
+
+const ChangelogModal = () => {
+  const { t } = useTranslation("changelog");
+
+  const features = t(`versions.${APP_VERSION}.features`, {
+    returnObjects: true,
+  });
+  const fixes = t(`versions.${APP_VERSION}.fixes`, { returnObjects: true });
+
+  const hasFeatures = Array.isArray(features) && features.length > 0;
+  const hasFixes = Array.isArray(fixes) && fixes.length > 0;
+  const hasContent = hasFeatures || hasFixes;
+
+  return (
+    <Stack>
+      {hasContent ? (
+        <>
+          {hasFeatures && (
+            <div>
+              <Title order={5} mb="xs">
+                {t("features")}
+              </Title>
+              <List>
+                {(features as string[]).map((feature) => (
+                  <List.Item key={feature}>{feature}</List.Item>
+                ))}
+              </List>
+            </div>
+          )}
+          {hasFixes && (
+            <div>
+              <Title order={5} mb="xs">
+                {t("fixes")}
+              </Title>
+              <List>
+                {(fixes as string[]).map((fix) => (
+                  <List.Item key={fix}>{fix}</List.Item>
+                ))}
+              </List>
+            </div>
+          )}
+        </>
+      ) : (
+        <Text fs="italic">{t("noChangelog")}</Text>
+      )}
+      <Button onClick={() => modals.close("changelog-modal")}>
+        {t("common:next")}
+      </Button>
+    </Stack>
+  );
+};
+
+export default ChangelogModal;

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -1,6 +1,13 @@
 import { getStaticPaths, makeStaticProperties } from "@lib/getStatic";
 import DefaultLayout from "@components/layouts/Default";
-import { Accordion, Container, SimpleGrid, Stack, Text } from "@mantine/core";
+import {
+  Accordion,
+  Button,
+  Container,
+  SimpleGrid,
+  Stack,
+  Text,
+} from "@mantine/core";
 import HeaderGreeting from "@components/HeaderGreeting";
 import useDefaultProfile from "@hooks/getDefaultProfile";
 import { useTranslation } from "next-i18next";
@@ -11,6 +18,7 @@ import { useEffect } from "react";
 import { APP_VERSION } from "@/utils/constants";
 import { modals } from "@mantine/modals";
 import Logger from "electron-log/renderer";
+import type { UpdateInfo } from "electron-updater";
 
 const IndexPage = () => {
   const defaultProfile = useDefaultProfile();
@@ -26,23 +34,67 @@ const IndexPage = () => {
         if (latestSeenVersion !== APP_VERSION) {
           // If the versions are different, it means the user hasn't seen the
           // changelog for the current version
-          modals.open({
-            modalId: "changelog-modal",
-            fullScreen: true,
-            title: t("changelogTitle", { VERSION: APP_VERSION }),
-            // TODO: Replace with actual changelog content
-            children: <Text>UPDATE_CHANGELOG_MESSAGE</Text>,
-            onClose: () => {
-              window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
-            },
-          });
+          window.ipc
+            .getUpdateInfo()
+            .then((updateInfo: UpdateInfo) => {
+              modals.open({
+                modalId: "changelog-modal",
+                fullScreen: true,
+                withCloseButton: false, // Only close with next button
+                title: t("changelogTitle", {
+                  VERSION: latestSeenVersion ?? APP_VERSION,
+                }),
+
+                children: (
+                  <>
+                    {updateInfo?.releaseNotes &&
+                    Array.isArray(updateInfo.releaseNotes) &&
+                    updateInfo.releaseNotes.length > 0 ? (
+                      updateInfo.releaseNotes.map((noteObj, index) => (
+                        <div key={index} style={{ marginBottom: 24 }}>
+                          <Text fw={700} mb={4}>
+                            {noteObj.version && (
+                              <>
+                                {t("versionLabel", {
+                                  VERSION: noteObj.version,
+                                })}
+                              </>
+                            )}
+                          </Text>
+                          <div
+                            dangerouslySetInnerHTML={{
+                              __html:
+                                typeof noteObj.note === "string"
+                                  ? noteObj.note
+                                  : String(noteObj.note),
+                            }}
+                          />
+                        </div>
+                      ))
+                    ) : (
+                      <Text fs="italic">{t("changelogNoInfo")}</Text>
+                    )}
+                    <Button onClick={() => modals.close("changelog-modal")}>
+                      {t("next")}
+                    </Button>
+                  </>
+                ),
+                onClose: () => {
+                  window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+                },
+              });
+            })
+            .catch((error) => {
+              console.error("Error fetching update info:", error);
+              Logger.error("Error fetching update info:", error);
+            });
         }
       })
       .catch((error) => {
         console.error("Error fetching latest seen changelog version:", error);
         Logger.error("Error fetching latest seen changelog version:", error);
       });
-  }, []);
+  }, [t]);
 
   return (
     <DefaultLayout withNavbarOpen>

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -1,12 +1,6 @@
 import { getStaticPaths, makeStaticProperties } from "@lib/getStatic";
 import DefaultLayout from "@components/layouts/Default";
-import {
-  Accordion,
-  Container,
-  SimpleGrid,
-  Stack,
-  Text,
-} from "@mantine/core";
+import { Accordion, Container, SimpleGrid, Stack, Text } from "@mantine/core";
 import HeaderGreeting from "@components/HeaderGreeting";
 import useDefaultProfile from "@hooks/getDefaultProfile";
 import { useTranslation } from "next-i18next";
@@ -92,6 +86,10 @@ const IndexPage = () => {
 
 export default IndexPage;
 
-export const getStaticProps = makeStaticProperties(["common", "gameModes", "changelog"]);
+export const getStaticProps = makeStaticProperties([
+  "common",
+  "gameModes",
+  "changelog",
+]);
 
 export { getStaticPaths };

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -7,10 +7,42 @@ import { useTranslation } from "next-i18next";
 import GameModeCard from "@components/content/GameModeCard";
 import { IconBarbell, IconTarget } from "@tabler/icons-react";
 import { MATCH_MODES, TRAINING_MODES } from "@utils/content/gameModes";
+import { useEffect } from "react";
+import { APP_VERSION } from "@/utils/constants";
+import { modals } from "@mantine/modals";
+import Logger from "electron-log/renderer";
 
 const IndexPage = () => {
   const defaultProfile = useDefaultProfile();
   const { t } = useTranslation();
+
+  // On a first load, check if the app has been updated
+  useEffect(() => {
+    // Check for latest seen changelog version in the electron store
+    // and compare it with the current app version
+    window.ipc
+      .getLatestSeenChangelogVersion()
+      .then((latestSeenVersion) => {
+        if (latestSeenVersion !== APP_VERSION) {
+          // If the versions are different, it means the user hasn't seen the
+          // changelog for the current version
+          modals.open({
+            modalId: "changelog-modal",
+            fullScreen: true,
+            title: t("changelogTitle", { VERSION: APP_VERSION }),
+            // TODO: Replace with actual changelog content
+            children: <Text>UPDATE_CHANGELOG_MESSAGE</Text>,
+            onClose: () => {
+              window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+            },
+          });
+        }
+      })
+      .catch((error) => {
+        console.error("Error fetching latest seen changelog version:", error);
+        Logger.error("Error fetching latest seen changelog version:", error);
+      });
+  }, []);
 
   return (
     <DefaultLayout withNavbarOpen>

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -32,7 +32,7 @@ const IndexPage = () => {
             title: t("changelogTitle", { VERSION: APP_VERSION }),
             children: <ChangelogModal />,
             onClose: () => {
-              window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+              window.ipc.setLatestSeenChangelogVersion(APP_VERSION);
             },
           });
         }

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -10,7 +10,7 @@ import { MATCH_MODES, TRAINING_MODES } from "@utils/content/gameModes";
 import { useEffect } from "react";
 import { APP_VERSION } from "@/utils/constants";
 import { modals } from "@mantine/modals";
-import Logger from "electron-log/renderer";
+import log from "electron-log/renderer";
 import ChangelogModal from "@/components/updater/ChangelogModal";
 
 const IndexPage = () => {
@@ -39,7 +39,7 @@ const IndexPage = () => {
       })
       .catch((error) => {
         console.error("Error fetching latest seen changelog version:", error);
-        Logger.error("Error fetching latest seen changelog version:", error);
+        log.error("Error fetching latest seen changelog version:", error);
       });
   }, [t]);
 

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -12,6 +12,7 @@ import { APP_VERSION } from "@/utils/constants";
 import { modals } from "@mantine/modals";
 import log from "electron-log/renderer";
 import ChangelogModal from "@/components/updater/ChangelogModal";
+import sharedChangelogModalProps from "@/utils/modals/sharedChangelogModalProps";
 
 const IndexPage = () => {
   const defaultProfile = useDefaultProfile();
@@ -26,16 +27,12 @@ const IndexPage = () => {
       .then((latestSeenVersion) => {
         if (latestSeenVersion !== APP_VERSION) {
           modals.open({
-            modalId: "changelog-modal",
-            fullScreen: true,
-            // Only close with next button
-            withCloseButton: false,
-            closeOnEscape: false,
             title: t("changelogTitle", { VERSION: APP_VERSION }),
             children: <ChangelogModal />,
             onClose: () => {
               window.ipc.setLatestSeenChangelogVersion(APP_VERSION);
             },
+            ...sharedChangelogModalProps,
           });
         }
       })

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -2,7 +2,6 @@ import { getStaticPaths, makeStaticProperties } from "@lib/getStatic";
 import DefaultLayout from "@components/layouts/Default";
 import {
   Accordion,
-  Button,
   Container,
   SimpleGrid,
   Stack,
@@ -18,7 +17,7 @@ import { useEffect } from "react";
 import { APP_VERSION } from "@/utils/constants";
 import { modals } from "@mantine/modals";
 import Logger from "electron-log/renderer";
-import type { UpdateInfo } from "electron-updater";
+import ChangelogModal from "@/components/updater/ChangelogModal";
 
 const IndexPage = () => {
   const defaultProfile = useDefaultProfile();
@@ -32,62 +31,16 @@ const IndexPage = () => {
       .getLatestSeenChangelogVersion()
       .then((latestSeenVersion) => {
         if (latestSeenVersion !== APP_VERSION) {
-          // If the versions are different, it means the user hasn't seen the
-          // changelog for the current version
-          window.ipc
-            .getUpdateInfo()
-            .then((updateInfo: UpdateInfo) => {
-              modals.open({
-                modalId: "changelog-modal",
-                fullScreen: true,
-                withCloseButton: false, // Only close with next button
-                title: t("changelogTitle", {
-                  VERSION: latestSeenVersion ?? APP_VERSION,
-                }),
-
-                children: (
-                  <>
-                    {updateInfo?.releaseNotes &&
-                    Array.isArray(updateInfo.releaseNotes) &&
-                    updateInfo.releaseNotes.length > 0 ? (
-                      updateInfo.releaseNotes.map((noteObj, index) => (
-                        <div key={index} style={{ marginBottom: 24 }}>
-                          <Text fw={700} mb={4}>
-                            {noteObj.version && (
-                              <>
-                                {t("versionLabel", {
-                                  VERSION: noteObj.version,
-                                })}
-                              </>
-                            )}
-                          </Text>
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html:
-                                typeof noteObj.note === "string"
-                                  ? noteObj.note
-                                  : String(noteObj.note),
-                            }}
-                          />
-                        </div>
-                      ))
-                    ) : (
-                      <Text fs="italic">{t("changelogNoInfo")}</Text>
-                    )}
-                    <Button onClick={() => modals.close("changelog-modal")}>
-                      {t("next")}
-                    </Button>
-                  </>
-                ),
-                onClose: () => {
-                  window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
-                },
-              });
-            })
-            .catch((error) => {
-              console.error("Error fetching update info:", error);
-              Logger.error("Error fetching update info:", error);
-            });
+          modals.open({
+            modalId: "changelog-modal",
+            fullScreen: true,
+            withCloseButton: false, // Only close with next button
+            title: t("changelogTitle", { VERSION: APP_VERSION }),
+            children: <ChangelogModal />,
+            onClose: () => {
+              window.ipc.setLatestSeenChangeLogVersion(APP_VERSION);
+            },
+          });
         }
       })
       .catch((error) => {
@@ -139,6 +92,6 @@ const IndexPage = () => {
 
 export default IndexPage;
 
-export const getStaticProps = makeStaticProperties(["common", "gameModes"]);
+export const getStaticProps = makeStaticProperties(["common", "gameModes", "changelog"]);
 
 export { getStaticPaths };

--- a/renderer/pages/[locale]/index.tsx
+++ b/renderer/pages/[locale]/index.tsx
@@ -28,7 +28,9 @@ const IndexPage = () => {
           modals.open({
             modalId: "changelog-modal",
             fullScreen: true,
-            withCloseButton: false, // Only close with next button
+            // Only close with next button
+            withCloseButton: false,
+            closeOnEscape: false,
             title: t("changelogTitle", { VERSION: APP_VERSION }),
             children: <ChangelogModal />,
             onClose: () => {

--- a/renderer/public/locales/de/changelog.json
+++ b/renderer/public/locales/de/changelog.json
@@ -1,0 +1,13 @@
+{
+  "noChangelog": "Dieses Update enthält verschiedene Fehlerbehebungen und Verbesserungen.",
+  "features": "Neuigkeiten",
+  "fixes": "Fehlerbehebungen",
+  "versions": {
+    "0.6.0": {
+      "features": [
+        "Verbesserte Update-Erfahrung mit lokalisierten Versionshinweisen"
+      ],
+      "fixes": []
+    }
+  }
+}

--- a/renderer/public/locales/de/common.json
+++ b/renderer/public/locales/de/common.json
@@ -102,5 +102,7 @@
   "country": "Land",
   "confirmCloseAppTitle": "{{APP_NAME}} wirklich beenden?",
   "confirmCloseAppText": "Möchten Sie die Anwendung wirklich schließen? Alle nicht gespeicherten Daten gehen verloren.",
-  "changelogTitle": "Neue Funktionen in Version {{VERSION}}"
+  "changelogTitle": "Neue Funktionen in Version {{VERSION}}",
+  "changelogNoInfo": "Keine Änderungsinformationen verfügbar...",
+  "versionLabel": "Version {{VERSION}}"
 }

--- a/renderer/public/locales/de/common.json
+++ b/renderer/public/locales/de/common.json
@@ -101,5 +101,6 @@
   "playGameMode": "{{GAME_MODE}} starten...",
   "country": "Land",
   "confirmCloseAppTitle": "{{APP_NAME}} wirklich beenden?",
-  "confirmCloseAppText": "Möchten Sie die Anwendung wirklich schließen? Alle nicht gespeicherten Daten gehen verloren."
+  "confirmCloseAppText": "Möchten Sie die Anwendung wirklich schließen? Alle nicht gespeicherten Daten gehen verloren.",
+  "changelogTitle": "Neue Funktionen in Version {{VERSION}}"
 }

--- a/renderer/public/locales/de/common.json
+++ b/renderer/public/locales/de/common.json
@@ -102,7 +102,7 @@
   "country": "Land",
   "confirmCloseAppTitle": "{{APP_NAME}} wirklich beenden?",
   "confirmCloseAppText": "Möchten Sie die Anwendung wirklich schließen? Alle nicht gespeicherten Daten gehen verloren.",
-  "openChangelog": "Was ist neu",
+  "openChangelog": "Was ist neu?",
   "changelogTitle": "Neue Funktionen in Version {{VERSION}}",
   "changelogNoInfo": "Keine Änderungsinformationen verfügbar...",
   "versionLabel": "Version {{VERSION}}"

--- a/renderer/public/locales/de/common.json
+++ b/renderer/public/locales/de/common.json
@@ -102,6 +102,7 @@
   "country": "Land",
   "confirmCloseAppTitle": "{{APP_NAME}} wirklich beenden?",
   "confirmCloseAppText": "Möchten Sie die Anwendung wirklich schließen? Alle nicht gespeicherten Daten gehen verloren.",
+  "openChangelog": "Was ist neu",
   "changelogTitle": "Neue Funktionen in Version {{VERSION}}",
   "changelogNoInfo": "Keine Änderungsinformationen verfügbar...",
   "versionLabel": "Version {{VERSION}}"

--- a/renderer/public/locales/en/changelog.json
+++ b/renderer/public/locales/en/changelog.json
@@ -1,0 +1,13 @@
+{
+  "noChangelog": "This update provides various bug fixes and improvements.",
+  "features": "What's New",
+  "fixes": "Bug Fixes",
+  "versions": {
+    "0.6.0": {
+      "features": [
+        "Improved update experience with localized release notes"
+      ],
+      "fixes": []
+    }
+  }
+}

--- a/renderer/public/locales/en/changelog.json
+++ b/renderer/public/locales/en/changelog.json
@@ -4,9 +4,7 @@
   "fixes": "Bug Fixes",
   "versions": {
     "0.6.0": {
-      "features": [
-        "Improved update experience with localized release notes"
-      ],
+      "features": ["Improved update experience with localized release notes"],
       "fixes": []
     }
   }

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -105,5 +105,5 @@
   "openChangelog": "What's New?",
   "changelogTitle": "New features in version {{VERSION}}",
   "changelogNoInfo": "No update details available...",
-  "versionLabel": "Version {{VERSION}}\n"
+  "versionLabel": "Version {{VERSION}}"
 }

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -102,6 +102,7 @@
   "country": "Country",
   "confirmCloseAppTitle": "Really quit {{APP_NAME}}?",
   "confirmCloseAppText": "Do you really want to close the application? All unsaved data will be lost.",
+  "openChangelog": "What's New",
   "changelogTitle": "New features in version {{VERSION}}",
   "changelogNoInfo": "No update details available...",
   "versionLabel": "Version {{VERSION}}\n"

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -101,5 +101,6 @@
   "playGameMode": "Start {{GAME_MODE}}...",
   "country": "Country",
   "confirmCloseAppTitle": "Really quit {{APP_NAME}}?",
-  "confirmCloseAppText": "Do you really want to close the application? All unsaved data will be lost."
+  "confirmCloseAppText": "Do you really want to close the application? All unsaved data will be lost.",
+  "changelogTitle": "New features in version {{VERSION}}"
 }

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -102,5 +102,7 @@
   "country": "Country",
   "confirmCloseAppTitle": "Really quit {{APP_NAME}}?",
   "confirmCloseAppText": "Do you really want to close the application? All unsaved data will be lost.",
-  "changelogTitle": "New features in version {{VERSION}}"
+  "changelogTitle": "New features in version {{VERSION}}",
+  "changelogNoInfo": "No update details available...",
+  "versionLabel": "Version {{VERSION}}\n"
 }

--- a/renderer/public/locales/en/common.json
+++ b/renderer/public/locales/en/common.json
@@ -102,7 +102,7 @@
   "country": "Country",
   "confirmCloseAppTitle": "Really quit {{APP_NAME}}?",
   "confirmCloseAppText": "Do you really want to close the application? All unsaved data will be lost.",
-  "openChangelog": "What's New",
+  "openChangelog": "What's New?",
   "changelogTitle": "New features in version {{VERSION}}",
   "changelogNoInfo": "No update details available...",
   "versionLabel": "Version {{VERSION}}\n"

--- a/renderer/utils/modals/sharedChangelogModalProps.ts
+++ b/renderer/utils/modals/sharedChangelogModalProps.ts
@@ -1,0 +1,14 @@
+import { ModalProps } from "@mantine/core";
+
+type SharedChangelogModalProps = Partial<ModalProps> & {
+  modalId: string;
+};
+
+const sharedChangelogModalProps: SharedChangelogModalProps = {
+  modalId: "changelog-modal",
+  fullScreen: true,
+  withCloseButton: false,
+  closeOnEscape: false,
+};
+
+export default sharedChangelogModalProps;


### PR DESCRIPTION
This pull request introduces a localized, automatic changelog modal that informs users about new features and fixes after an app update. The modal appears on first launch after an update or can be opened manually from the navbar. The implementation includes persistent tracking of the last seen changelog version and adds localization support for changelog content.

The most important changes are:

**Changelog Modal Feature:**
* Added a new `ChangelogModal` component that displays localized release notes for the current app version, including features and fixes, with translations in English and German (`renderer/components/updater/ChangelogModal.tsx`, `renderer/public/locales/en/changelog.json`, `renderer/public/locales/de/changelog.json`). [[1]](diffhunk://#diff-59d92678cdeb8a3b3af258af42329c510c4dbb82c756674b9b8c8772e8b397eeR1-R57) [[2]](diffhunk://#diff-5b32b9443bae78ccb18c1abff78b2b08a538ac5b8d67b48e6ec3458a7aa23f86R1-R13) [[3]](diffhunk://#diff-66e11ffad78fcd2d958207c65c46a13ff19a73ff455ce69612fc63aba2bc9211R1-R13)
* Integrated the modal to show automatically on the home page after an update, and to be opened manually from the navbar via a new "What's New?" link (`renderer/pages/[locale]/index.tsx`, `renderer/components/layouts/shared/AppNavbar.tsx`). ([renderer/pages/[locale]/index.tsxL3-R51](diffhunk://#diff-d02d45b1b241c9fa14975f319e44cd15c38fd6f274a19bbfeec33d4f6084d7ddL3-R51), [renderer/pages/[locale]/index.tsxL58-R95](diffhunk://#diff-d02d45b1b241c9fa14975f319e44cd15c38fd6f274a19bbfeec33d4f6084d7ddL58-R95), [[1]](diffhunk://#diff-1d84082152b1621962e85bbcda8451f2322dfc5376f5fbf0daab97436f3b65aeR14-L17) [[2]](diffhunk://#diff-1d84082152b1621962e85bbcda8451f2322dfc5376f5fbf0daab97436f3b65aeR48-R62) [[3]](diffhunk://#diff-1d84082152b1621962e85bbcda8451f2322dfc5376f5fbf0daab97436f3b65aeR96-R106)

**Persistent Changelog Tracking:**
* Added IPC handlers and store logic to persist and retrieve the latest seen changelog version, ensuring the modal only appears once per version (`main/helpers/ipc.ts`, `main/helpers/stores.ts`, `main/preload.ts`). [[1]](diffhunk://#diff-37bad3577f8a42e8cd85b9ba491d3017ec65de0249d528174fbb5083ba9abd71R27-R36) [[2]](diffhunk://#diff-0d6548e2f2e2853a09396a07d3bb67de61a2cd035bd7769361f80d27789f3cfeR8) [[3]](diffhunk://#diff-874589bbed0092483a71c0c09d7ff07fe89b2e88f56e962fa44157663b1056a9R25-R30)

**Localization and UI Texts:**
* Updated localization files to include new strings for the changelog modal and navigation (`renderer/public/locales/en/common.json`, `renderer/public/locales/de/common.json`). [[1]](diffhunk://#diff-d758a4b87bc41eb48a3c7c364ec6f2a1481571708c7c9c69b2111c94e0d62c3cL104-R108) [[2]](diffhunk://#diff-584528a638eef5d048d82818f21db07c6cf23cc123018136da56bd58c519ee9eL104-R108)

**Miscellaneous:**
* Updated static properties loader to include the changelog namespace for translations (`renderer/pages/[locale]/index.tsx`). ([renderer/pages/[locale]/index.tsxL58-R95](diffhunk://#diff-d02d45b1b241c9fa14975f319e44cd15c38fd6f274a19bbfeec33d4f6084d7ddL58-R95))
* Minor refactor in updater event handling to improve readability (`main/helpers/updater.ts`).

These changes collectively improve user awareness of new features and bug fixes, enhance the update experience, and ensure internationalization support.