### PR TITLE
feat(ci): add multi-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build application on all platforms
 
-# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+# Keep workflow permissions minimal; `actions: write` is required by `actions/cache`
+# to save npm/electron caches, while `contents` only needs read access.
 permissions:
   actions: write # Needed for caching npm dependencies
   contents: read
@@ -14,15 +15,28 @@ on:
   # branches: [main]
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            build-script: build:linux
+          - os: windows-latest
+            # 32-bit (build:win32) is intentionally skipped;
+            # Windows 10/11 dropped 32-bit support in 2020.
+            build-script: build:win64
+          - os: macos-latest
+            build-script: build:mac
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
-      - name: Cache electron + npm
+      - name: Cache Electron binaries (Unix)
+        if: runner.os != 'Windows'
         uses: actions/cache@v4
         with:
           path: |
@@ -30,15 +44,21 @@ jobs:
             ~/.cache/electron-builder
             ~/Library/Caches/electron
             ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+      - name: Cache Electron binaries (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v4
+        with:
+          path: |
             ${{ env.LOCALAPPDATA }}\electron
             ${{ env.LOCALAPPDATA }}\electron-builder
-            ~/.npm
-            node_modules
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-
+            ${{ runner.os }}-electron-
       - run: npm ci
-      - run: npm run build:linux
+      - run: npm run ${{ matrix.build-script }}
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -48,91 +68,3 @@ jobs:
             release/**
             build/**
             out/**
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
-      - name: Cache electron + npm
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
-            ~/Library/Caches/electron
-            ~/Library/Caches/electron-builder
-            ${{ env.LOCALAPPDATA }}\electron
-            ${{ env.LOCALAPPDATA }}\electron-builder
-            ~/.npm
-            node_modules
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-      - run: npm ci
-      - run: npm run build:win64
-
-      # 32 bit is dropped by Windows 10/11 in 2020, so we can
-      # skip it. Maybe we should remove the build script in
-      # the future as well?
-
-      # npm run build:win32
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: app-${{ runner.os }}
-          path: |
-            dist/**
-            release/**
-            build/**
-            out/**
-
-  build-macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
-      - name: Cache electron + npm
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
-            ~/Library/Caches/electron
-            ~/Library/Caches/electron-builder
-            ${{ env.LOCALAPPDATA }}\electron
-            ${{ env.LOCALAPPDATA }}\electron-builder
-            ~/.npm
-            node_modules
-          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-      - name: Cache electron + npm (macOS)
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
-            ~/Library/Caches/electron
-            ~/Library/Caches/electron-builder
-            ~/.npm
-          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-electron-
-      - name: Cache electron + npm (Linux)
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/electron
-            ~/.cache/electron-builder
-            ~/.npm
-          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-electron-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,3 +68,6 @@ jobs:
             release/**
             build/**
             out/**
+          # Retain artifacts for 7 days to allow time for manual download and testing.
+          # Then they will be automatically deleted to save storage space.
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,138 @@
+name: Build application on all platforms
+
+# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+permissions:
+  actions: write # Needed for caching npm dependencies
+  contents: read
+
+# We only need to check if the build works on push to main,
+# as we have linting and formatting checks on pull requests.
+on:
+  push:
+    branches: [main]
+  # pull_request:
+  # branches: [main]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+      - name: Cache electron + npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ${{ env.LOCALAPPDATA }}\electron
+            ${{ env.LOCALAPPDATA }}\electron-builder
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+      - run: npm ci
+      - run: npm run build:linux
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ runner.os }}
+          path: |
+            dist/**
+            release/**
+            build/**
+            out/**
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+      - name: Cache electron + npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ${{ env.LOCALAPPDATA }}\electron
+            ${{ env.LOCALAPPDATA }}\electron-builder
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+      - run: npm ci
+      - run: npm run build:win64
+
+      # 32 bit is dropped by Windows 10/11 in 2020, so we can
+      # skip it. Maybe we should remove the build script in
+      # the future as well?
+
+      # npm run build:win32
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-${{ runner.os }}
+          path: |
+            dist/**
+            release/**
+            build/**
+            out/**
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+      - name: Cache electron + npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ${{ env.LOCALAPPDATA }}\electron
+            ${{ env.LOCALAPPDATA }}\electron-builder
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+      - name: Cache electron + npm (macOS)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~/.npm
+          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
+      - name: Cache electron + npm (Linux)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/.npm
+          key: ${{ runner.os }}-electron-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint and format code
 
-# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+# Keep workflow permissions minimal; `actions: write` is required by `actions/setup-node`
+# to save the npm cache, while `contents` only needs read access.
 permissions:
   actions: write # Needed for caching npm dependencies
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Run all Tests
 
-# Remove the write permissions, see CodeQL `actions/missing-workflow-permissions`
+# Keep workflow permissions minimal; `actions: write` is required by `actions/setup-node`
+# to save the npm cache, while `contents` only needs read access.
 permissions:
   actions: write # Needed for caching npm dependencies
   contents: read


### PR DESCRIPTION
Introduce a new GitHub Actions workflow to build the application on Linux, Windows and macOS. The workflow sets up Node 24, enables npm/electron caching, runs CI install and platform-specific build scripts, and uploads build artifacts. It runs on push to main (PR trigger is commented out) and adjusts workflow permissions for caching; Windows 32-bit build is intentionally skipped.