### PR TITLE
fix(layout): only controls layout is now draggable and has horizontal padding

### DIFF
--- a/renderer/components/layouts/OnlyControlsLayout.tsx
+++ b/renderer/components/layouts/OnlyControlsLayout.tsx
@@ -17,7 +17,7 @@ const OnlyControlsLayout = ({
       }}
       {...props}
     >
-      <AppShell.Header>
+      <AppShell.Header className="draggable" px={APP_SHELL.HEADER_PADDING}>
         <WindowControls />
       </AppShell.Header>
       <AppShell.Main>{children}</AppShell.Main>

--- a/renderer/components/layouts/shared/AppHeader.tsx
+++ b/renderer/components/layouts/shared/AppHeader.tsx
@@ -27,7 +27,7 @@ const AppHeader = () => {
         justify="space-between"
         h={APP_SHELL.HEADER_HEIGHT}
         mah={APP_SHELL.HEADER_HEIGHT}
-        px="sm"
+        px={APP_SHELL.HEADER_PADDING}
         w="100%"
       >
         <Group gap="lg">

--- a/renderer/utils/constants.ts
+++ b/renderer/utils/constants.ts
@@ -1,3 +1,4 @@
+import type { MantineSpacing } from "@mantine/core";
 import pkg from "../../package.json";
 import { Checkout, MatchStatus } from "types/match";
 
@@ -64,9 +65,14 @@ export const NOTIFICATION_LIMIT = 3;
 /**
  * Constants related to the AppShell layout components.
  */
-export const APP_SHELL = {
+export const APP_SHELL: {
+  ICON_SIZE: number;
+  HEADER_HEIGHT: number;
+  NAVBAR_WIDTH: number;
+  HEADER_PADDING: MantineSpacing;
+} = {
   ICON_SIZE: 24, // px
   HEADER_HEIGHT: 32, // px
   NAVBAR_WIDTH: 200, // px
-  HEADER_PADDING: "sm", // Mantine spacing value
+  HEADER_PADDING: "sm",
 };

--- a/renderer/utils/constants.ts
+++ b/renderer/utils/constants.ts
@@ -68,4 +68,5 @@ export const APP_SHELL = {
   ICON_SIZE: 24, // px
   HEADER_HEIGHT: 32, // px
   NAVBAR_WIDTH: 200, // px
+  HEADER_PADDING: "sm", // Mantine spacing value
 };


### PR DESCRIPTION
This pull request standardizes the header padding in the application's layout components by introducing a new constant and updating relevant usages. The most important changes are:

**UI Consistency Improvements:**

* Added a new `HEADER_PADDING` constant to the `APP_SHELL` object in `constants.ts` to centralize the header padding value.
* Updated `AppHeader` and `OnlyControlsLayout` components to use the new `APP_SHELL.HEADER_PADDING` value for horizontal padding, ensuring consistent spacing across headers. [[1]](diffhunk://#diff-a5f9e529c4771cb0decc64772e3fd406cb6e88c5d8571fcc1bceafbe42efe5ceL30-R30) [[2]](diffhunk://#diff-bb10a4adb5d85629ff0446e1b1da8f41f86247c53fadca72f0a4a7ecfd144706L20-R20)

**Code Maintainability:**

* Applied the `draggable` class to the `AppShell.Header` in `OnlyControlsLayout` for improved window control behavior.